### PR TITLE
Fix an SVG bug to improve browser support

### DIFF
--- a/app/views/badges/render.haml
+++ b/app/views/badges/render.haml
@@ -1,7 +1,7 @@
 !!! XML
 %svg{height: "20", width: width, xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
   %a{"xlink:href"=> absolute_url(:badges, :show, id: params[:id]), target: '_blank'}
-    %lineargradient#a{x2: "0", y2: "100%"}
+    %linearGradient#a{x2: "0", y2: "100%"}
       %stop{offset: "0", "stop-color" => "#bbb", "stop-opacity" => ".1"}
       %stop{offset: "1", "stop-opacity" => ".1"}
     %rect{fill: "#555", height: "20", rx: "3", width: width}

--- a/app/views/badges/static.haml
+++ b/app/views/badges/static.haml
@@ -1,7 +1,7 @@
 !!! XML
 %svg{height: "20", width: width, xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
   %a{"xlink:href"=> absolute_url(:static, :index), target: '_blank'}
-    %lineargradient#a{x2: "0", y2: "100%"}
+    %linearGradient#a{x2: "0", y2: "100%"}
       %stop{offset: "0", "stop-color" => "#bbb", "stop-opacity" => ".1"}
       %stop{offset: "1", "stop-opacity" => ".1"}
     %rect{fill: "#555", height: "20", rx: "3", width: width}


### PR DESCRIPTION
Fixes #3.

SVG is case-sensitive so we need to use camel casing in the `<linearGradient>` tag. Interestingly, all the browsers seem to fail to some degree at parsing the linear gradient in the SVG when using an `<img>` tag. On the other hand, Firefox and Chrome are able to display the SVG perfectly if embed the `<svg>` into HTML directly (rather than via an `<img>` tag).

![screen shot 2016-02-09 at 2 56 31 am](https://cloud.githubusercontent.com/assets/1151810/12910524/750d4210-ced9-11e5-8aed-aa908d071df4.png)

In order: Safari, Firefox and Chrome
